### PR TITLE
bump gpt version to gpt-4

### DIFF
--- a/bot/chat-gpt/prompt.ts
+++ b/bot/chat-gpt/prompt.ts
@@ -41,7 +41,7 @@ export async function handlePrompt(client: APTClient, message: Message) {
         }
       ],
       temperature: 0.7,
-      model: 'gpt-4',
+      model: 'gpt-4-1106-preview',
     })
 
     const promptParams = {

--- a/bot/chat-gpt/prompt.ts
+++ b/bot/chat-gpt/prompt.ts
@@ -41,7 +41,7 @@ export async function handlePrompt(client: APTClient, message: Message) {
         }
       ],
       temperature: 0.7,
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-4',
     })
 
     const promptParams = {


### PR DESCRIPTION
Uses `gpt-4` model instead of `gpt-3.5-turbo`.


:warning: this break the usage command but 🤷 